### PR TITLE
Peter/fix netcdf4 invalid literal

### DIFF
--- a/scripts/qcio.py
+++ b/scripts/qcio.py
@@ -1586,6 +1586,8 @@ def nc_read_series(ncFullName,checktimestep=True,fixtimestepmethod=""):
             raise Exception("nc_read_series: file not found")
     # file probably exists, so let's read it
     ncFile = netCDF4.Dataset(ncFullName,'r')
+    # disable automatic masking of data when valid_range specified
+    ncFile.set_auto_mask(False)
     # now deal with the global attributes
     gattrlist = ncFile.ncattrs()
     if len(gattrlist)!=0:

--- a/scripts/qcio.py
+++ b/scripts/qcio.py
@@ -1735,6 +1735,7 @@ def nc_read_var(ncFile,ThisOne):
         data = ncFile.variables[ThisOne][:,0,0]
         # netCDF4 returns a masked array if the "missing_variable" attribute has been set
         # for the variable, here we trap this and force the array in ds.series to be ndarray
+        # may not be needed after adding ncFile.set_auto_mask(False) in nc_read_series().
         if numpy.ma.isMA(data): data,dummy = qcutils.MAtoSeries(data)
         # check for a QC flag
         if ThisOne+'_QCFlag' in ncFile.variables.keys():


### PR DESCRIPTION
Update to netcdf4 V1.3.1 caused "invalid literal for int()" with valid_range attribute set to "-1e35, 1e35".
Disabled automatic conversion to masked array as a fix.