### PR TITLE
Fix bug in detecting missing data values (3 routines).

### DIFF
--- a/scripts/qcck.py
+++ b/scripts/qcck.py
@@ -437,7 +437,7 @@ def do_diurnalcheck(cf,ds,section,series,code=5):
             lHdh = ds.series['Hdh']['Data'][mindex]
             l2ds = ds.series[series]['Data'][mindex]
             for i in range(nInts):
-                li = numpy.where(abs(lHdh-(float(i)/float(n))<c.eps)&(l2ds!=float(c.missing_value)))
+                li = numpy.where((abs(lHdh-(float(i)/float(n)))<c.eps)&(l2ds!=float(c.missing_value)))
                 if numpy.size(li)!=0:
                     Av[i] = numpy.mean(l2ds[li])
                     Sd[i] = numpy.std(l2ds[li])

--- a/scripts/qcgf.py
+++ b/scripts/qcgf.py
@@ -3227,12 +3227,19 @@ def gfSOLO_runsofm(dsa,dsb,driverlist,targetlabel,nRecs,si=0,ei=-1):
     # now fill the driver data array
     i = 0
     badlines = []
+    baddates = []
+    badvalues = []
     for TheseOnes in driverlist:
         driver,flag,attr = qcutils.GetSeries(dsb,TheseOnes,si=si,ei=ei)
-        index = numpy.where(abs(driver-float(c.missing_value)<c.eps))[0]
+        index = numpy.where(abs(driver-float(c.missing_value))<c.eps)[0]
         if len(index)!=0:
             logger.error(' GapFillUsingSOLO: c.missing_value found in driver '+TheseOnes+' at lines '+str(index))
             badlines = badlines+index.tolist()
+            for n in index:
+                baddates.append(dsb.series["DateTime"]["Data"][n])
+                badvalues.append(dsb.series[TheseOnes]["Data"][n])
+            logger.error(' GapFillUsingSOLO: driver values: '+str(badvalues))
+            logger.error(' GapFillUsingSOLO: datetimes: '+str(baddates))
         sofminputdata[:,i] = driver[:]
         i = i + 1
     if len(badlines)!=0:

--- a/scripts/qcrpNN.py
+++ b/scripts/qcrpNN.py
@@ -1450,7 +1450,7 @@ def rpSOLO_runsofm(ds,SOLO_gui,driverlist,targetlabel,nRecs,si=0,ei=-1):
     badlines = []
     for TheseOnes in driverlist:
         driver,flag,attr = qcutils.GetSeries(ds,TheseOnes,si=si,ei=ei)
-        index = numpy.where(abs(driver-float(c.missing_value)<c.eps))[0]
+        index = numpy.where(abs(driver-float(c.missing_value))<c.eps)[0]
         if len(index)!=0:
             logger.error(' SOLO_runsofm: c.missing_value found in driver '+TheseOnes+' at lines '+str(index))
             badlines = badlines+index.tolist()


### PR DESCRIPTION
Typos fixed in numpy.where statements in:
1) qcrp.gf_SOLO_runsofm()
2) qcck.do_diurnalcheck()
3) qcrpNN.rpSOLO_runsofm()
The typo was causing false identification of missing data (right parentheses in wrong place).