### PR TITLE
Peter/make it faster

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -39,13 +39,11 @@ dir_list = ["./solo/inf","./solo/input","./solo/log","./solo/output"]
 for item in dir_list:
     if not os.path.exists(item): os.makedirs(item)
 
-#logging.basicConfig(filename='logfiles/OzFluxQC.log',level=logging.DEBUG)
-#console = logging.StreamHandler()
-#formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s', '%H:%M:%S')
-#console.setFormatter(formatter)
-#console.setLevel(logging.INFO)
-#logging.getLogger('').addHandler(console)
-logger = qclog.init_logger()
+# start a log file with the current date and time in the name
+t = time.localtime()
+rundatetime = datetime.datetime(t[0],t[1],t[2],t[3],t[4],t[5]).strftime("%Y%m%d%H%M")
+log_filename = 'pfp_'+rundatetime+'.log'
+logger = qclog.init_logger(logger_name="pfp_log", file_handler=log_filename)
 
 class qcgui(tk.Tk):
     """

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,22 @@
 version_name = "PyFluxPro"
-version_number = "V0.1.2"
+version_number = "V0.1.3"
+# V0.1.3 - "make it faster" version
+#        - at some stage, about the time OFQC became PFP, PFP
+#          became very slow, especially monthly summaries at
+#          L6.  The suspect was the use of qcutils.GetVariables()
+#          which I've been using to replace GetSeriesasMA().
+#          Some quick profiling in Jupyter showed that
+#          GetSeriesasMA() took ~750 us to produce the data
+#          compared to ~350 ms for GetVariables(), that's a
+#          factor of 500 slower!
+#        - the culprit turned out to be the use of numpy.array()
+#          to convert the datetime (originally a list) to an
+#          array (~85 ms) plus some unnecessary use of
+#          qcutils.get_start_index() and get_end_index().
+#        - the fix was to re-write PFP so that datetime is stored
+#          in the data structure as an array rather than a list plus
+#          some changes to GetDateIndex(), FindIndicesOfBInA()
+#          and sundry other routines.
 # V0.1.2 - version produced during resolution of differences
 #          between OFQC V2.9.6 and PFP V0.1.1 found by Craig
 #          McFarlane at Great Western Woodlands:

--- a/scripts/qcck.py
+++ b/scripts/qcck.py
@@ -528,11 +528,13 @@ def do_excludedates(cf,ds,section,series,code=6):
     for i in range(NumExclude):
         ExcludeDateList = ast.literal_eval(cf[section][series]['ExcludeDates'][str(i)])
         try:
-            si = ldt.index(datetime.datetime.strptime(ExcludeDateList[0],'%Y-%m-%d %H:%M'))
+            dt = datetime.datetime.strptime(ExcludeDateList[0],'%Y-%m-%d %H:%M')
+            si = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             si = 0
         try:
-            ei = ldt.index(datetime.datetime.strptime(ExcludeDateList[1],'%Y-%m-%d %H:%M')) + 1
+            dt = datetime.datetime.strptime(ExcludeDateList[1],'%Y-%m-%d %H:%M')
+            ei = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             ei = -1
         ds.series[series]['Data'][si:ei] = numpy.float64(c.missing_value)
@@ -549,11 +551,13 @@ def do_excludehours(cf,ds,section,series,code=7):
     for i in range(NumExclude):
         ExcludeHourList = ast.literal_eval(cf[section][series]['ExcludeHours'][str(i)])
         try:
-            si = ldt.index(datetime.datetime.strptime(ExcludeHourList[0],'%Y-%m-%d %H:%M'))
+            dt = datetime.datetime.strptime(ExcludeHourList[0],'%Y-%m-%d %H:%M')
+            si = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             si = 0
         try:
-            ei = ldt.index(datetime.datetime.strptime(ExcludeHourList[1],'%Y-%m-%d %H:%M')) + 1
+            dt = datetime.datetime.strptime(ExcludeHourList[1],'%Y-%m-%d %H:%M')
+            ei = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             ei = -1
         for j in range(len(ExcludeHourList[2])):

--- a/scripts/qcgf.py
+++ b/scripts/qcgf.py
@@ -298,11 +298,9 @@ def gfClimatology_interpolateddaily(ds,series,output,xlbooks):
     # actually ...
     # this may not be the fastest but it may be the most robust because it matches dates of missing data
     # to dates in the climatology file
-    li = 0
     for ii in idx:
         try:
-            jj = cdt.index(ldt[ii],li)
-            li = jj
+            jj = qcutils.find_nearest_value(cdt, ldt[ii])
             data[ii] = val1d[jj]
             flag[ii] = numpy.int32(40)
         except ValueError:
@@ -1427,9 +1425,12 @@ def gfalternate_matchstartendtimes(ds,ds_alternate):
     # do the alternate and tower data overlap?
     if overlap:
         # index of alternate datetimes that are also in tower datetimes
-        alternate_index = qcutils.FindIndicesOfBInA(ldt_tower,ldt_alternate)
+        #alternate_index = qcutils.FindIndicesOfBInA(ldt_tower,ldt_alternate)
+        #alternate_index = [qcutils.find_nearest_value(ldt_tower, dt) for dt in ldt_alternate]
         # index of tower datetimes that are also in alternate datetimes
-        tower_index = qcutils.FindIndicesOfBInA(ldt_alternate,ldt_tower)
+        #tower_index = qcutils.FindIndicesOfBInA(ldt_alternate,ldt_tower)
+        #tower_index = [qcutils.find_nearest_value(ldt_alternate, dt) for dt in ldt_tower]
+        tower_index, alternate_index = qcutils.FindMatchingIndices(ldt_tower, ldt_alternate)
         # check that the indices point to the same times
         ldta = [ldt_alternate[i] for i in alternate_index]
         ldtt = [ldt_tower[i] for i in tower_index]
@@ -2636,7 +2637,7 @@ def gfSOLO_plot(pd,dsa,dsb,driverlist,targetlabel,outputlabel,solo_info,si=0,ei=
     # get the time step
     ts = int(dsb.globalattributes['time_step'])
     # get a local copy of the datetime series
-    xdt = numpy.array(dsb.series['DateTime']['Data'][si:ei+1])
+    xdt = dsb.series["DateTime"]["Data"][si:ei+1]
     Hdh,f,a = qcutils.GetSeriesasMA(dsb,'Hdh',si=si,ei=ei)
     # get the observed and modelled values
     obs,f,a = qcutils.GetSeriesasMA(dsb,targetlabel,si=si,ei=ei)

--- a/scripts/qcio.py
+++ b/scripts/qcio.py
@@ -1604,7 +1604,6 @@ def nc_read_series(ncFullName,checktimestep=True,fixtimestepmethod=""):
     if len(gattrlist)!=0:
         for gattr in gattrlist:
             ds.globalattributes[gattr] = getattr(ncFile,gattr)
-        if "time_step" in ds.globalattributes: c.ts = ds.globalattributes["time_step"]
     # get a list of the variables in the netCDF file (not their QC flags)
     varlist = [x for x in ncFile.variables.keys() if "_QCFlag" not in x]
     for ThisOne in varlist:
@@ -1671,7 +1670,6 @@ def nc_read_todf(ncFullName,var_data=[]):
         gattr = {}
         for attr in gattrlist:
             gattr[attr] = getattr(ncFile,attr)
-            if "time_step" in gattr.keys(): c.ts = gattr["time_step"]
     # get a list of Python datetimes from the xlDatetime
     # this may be better replaced with one of the standard OzFluxQC routines
     dates_list=[datetime.datetime(*xlrd.xldate_as_tuple(elem,0)) for elem in ncFile.variables['xlDateTime']]

--- a/scripts/qcls.py
+++ b/scripts/qcls.py
@@ -380,7 +380,7 @@ def l6qc(cf,ds5):
     Fc_list = [label for label in ds6.series.keys() if label[0:2] == "Fc"]
     qcutils.CheckUnits(ds6, Fc_list, "umol/m2/s", convert_units=True)
     ## apply the turbulence filter (if requested)
-    #qcck.ApplyTurbulenceFilter(cf,ds6)
+    qcck.ApplyTurbulenceFilter(cf,ds6)
     # get ER from the observed Fc
     qcrp.GetERFromFc(cf, ds6, l6_info)
     # estimate ER using SOLO

--- a/scripts/qcts.py
+++ b/scripts/qcts.py
@@ -91,11 +91,13 @@ def ApplyLinear(cf,ds,ThisOne):
         for i in range(len(LinearList)):
             LinearItemList = ast.literal_eval(cf['Variables'][ThisOne]['Linear'][str(i)])
             try:
-                si = ldt.index(datetime.datetime.strptime(LinearItemList[0],'%Y-%m-%d %H:%M'))
+                dt = datetime.datetime.strptime(LinearItemList[0],'%Y-%m-%d %H:%M')
+                si = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 si = 0
             try:
-                ei = ldt.index(datetime.datetime.strptime(LinearItemList[1],'%Y-%m-%d %H:%M')) + 1
+                dt = datetime.datetime.strptime(LinearItemList[1],'%Y-%m-%d %H:%M')
+                ei = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 ei = -1
             Slope = float(LinearItemList[2])
@@ -130,11 +132,13 @@ def ApplyLinearDrift(cf,ds,ThisOne):
         for i in range(len(DriftList)):
             DriftItemList = ast.literal_eval(cf['Variables'][ThisOne]['Drift'][str(i)])
             try:
-                si = ldt.index(datetime.datetime.strptime(DriftItemList[0],'%Y-%m-%d %H:%M'))
+                dt = datetime.datetime.strptime(DriftItemList[0],'%Y-%m-%d %H:%M')
+                si = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 si = 0
             try:
-                ei = ldt.index(datetime.datetime.strptime(DriftItemList[1],'%Y-%m-%d %H:%M')) + 1
+                dt = datetime.datetime.strptime(DriftItemList[1],'%Y-%m-%d %H:%M') + 1
+                ei = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 ei = -1
             Slope = numpy.zeros(len(data))
@@ -174,11 +178,13 @@ def ApplyLinearDriftLocal(cf,ds,ThisOne):
         for i in range(len(DriftList)):
             DriftItemList = ast.literal_eval(cf['Variables'][ThisOne]['LocalDrift'][str(i)])
             try:
-                si = ldt.index(datetime.datetime.strptime(DriftItemList[0],'%Y-%m-%d %H:%M'))
+                dt = datetime.datetime.strptime(DriftItemList[0],'%Y-%m-%d %H:%M')
+                si = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 si = 0
             try:
-                ei = ldt.index(datetime.datetime.strptime(DriftItemList[1],'%Y-%m-%d %H:%M')) + 1
+                dt = datetime.datetime.strptime(DriftItemList[1],'%Y-%m-%d %H:%M') + 1
+                ei = qcutils.find_nearest_value(ldt, dt)
             except ValueError:
                 ei = -1
             Slope = numpy.zeros(len(data))
@@ -1389,11 +1395,13 @@ def CorrectWindDirection(cf,ds,Wd_in):
     for i in range(len(KeyList)):
         ItemList = ast.literal_eval(cf['Variables'][Wd_in]['CorrectWindDirection'][str(i)])
         try:
-            si = ldt.index(datetime.datetime.strptime(ItemList[0],'%Y-%m-%d %H:%M'))
+            dt = datetime.datetime.strptime(ItemList[0],'%Y-%m-%d %H:%M')
+            si = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             si = 0
         try:
-            ei = ldt.index(datetime.datetime.strptime(ItemList[1],'%Y-%m-%d %H:%M')) + 1
+            dt = datetime.datetime.strptime(ItemList[1],'%Y-%m-%d %H:%M')
+            ei = qcutils.find_nearest_value(ldt, dt)
         except ValueError:
             ei = -1
         Correction = float(ItemList[2])


### PR DESCRIPTION
PFP V0.1.2 was slow, culprit was thought to be qcutils.GetVariable(), turns out GetVariable() was ~500 times slower than GetSeriesasMA()!
Major contributor was use of numpy.array() for DateTime in the return statement.  So, re-wrote everything to change DateTime in data structure from list (V0.1.2) to numpy.ndarray (V0.1.3).  Plus various other changes (qcutils.FindIndicesOfBInA() etc) as required.
PFP V0.1.3 execution speed now similar to OFQC V2.9.6.
Tested changes by comparing cumulative NEE from V0.1.2 and V0.1.3, ~10 gC/m2 difference (in ~600 gC/m2) between V0.1.2 and V0.1.3.  Difference small so not investigating further at the stage.