### PR TITLE
Changes to gap-filling using "days" - read GUIs start and enddate and…

### DIFF
--- a/scripts/qcgf.py
+++ b/scripts/qcgf.py
@@ -3001,21 +3001,28 @@ def gfSOLO_run_gui(dsa,dsb,solo_gui,solo_info):
     elif solo_gui.peropt.get()==3:
         gfSOLO_progress(solo_gui,"Starting auto (days) run ...")
         # get the start datetime entered in the SOLO GUI
-        if len(solo_gui.startEntry.get())!=0: solo_info["startdate"] = solo_gui.startEntry.get()
+        if len(solo_gui.startEntry.get())!=0: solo_info["startdate"] = solo_gui.startEntry.get()  # if you read the GUIs startdate
+        if len(solo_gui.endEntry.get())!=0: solo_info["enddate"] = solo_gui.endEntry.get()        # you need to include end date too
+        solo_info["gui_startdate"] = solo_info["startdate"]
+        solo_info["gui_enddate"] = solo_info["enddate"]
         startdate = dateutil.parser.parse(solo_info["startdate"])
+        gui_enddate = dateutil.parser.parse(solo_info["gui_enddate"])
         file_startdate = dateutil.parser.parse(solo_info["file_startdate"])
         file_enddate = dateutil.parser.parse(solo_info["file_enddate"])
         nDays = int(solo_gui.daysEntry.get())
         enddate = startdate+dateutil.relativedelta.relativedelta(days=nDays)
-        enddate = min([file_enddate,enddate])
+        enddate = min([file_enddate,enddate,gui_enddate])
         solo_info["enddate"] = datetime.datetime.strftime(enddate,"%Y-%m-%d %H:%M")
-        while startdate<file_enddate:
+        solo_info["startdate"] = datetime.datetime.strftime(startdate,"%Y-%m-%d %H:%M")
+        stopdate = min([file_enddate,gui_enddate])
+        while startdate<stopdate: #file_enddate:
             gfSOLO_main(dsa,dsb,solo_info)
             gfSOLO_plotcoveragelines(dsb,solo_info)
             startdate = enddate
             enddate = startdate+dateutil.relativedelta.relativedelta(days=nDays)
+            run_enddate = min([stopdate,enddate])
             solo_info["startdate"] = startdate.strftime("%Y-%m-%d %H:%M")
-            solo_info["enddate"] = enddate.strftime("%Y-%m-%d %H:%M")
+            solo_info["enddate"] = run_enddate.strftime("%Y-%m-%d %H:%M")
         # now fill any remaining gaps
         gfSOLO_autocomplete(dsa,dsb,solo_info)
         # write Excel spreadsheet with fit statistics

--- a/scripts/qcrp.py
+++ b/scripts/qcrp.py
@@ -176,7 +176,7 @@ def ERUsingFFNET(cf, ds, info):
     call_mode = qcutils.get_keyvaluefromcf(cf,["Options"],"call_mode",default="interactive")
     FFNET_info["call_mode"]= call_mode
     if call_mode.lower()=="interactive":
-        FFNET_info["show_plots"] = True
+        #FFNET_info["show_plots"] = True
         # call the FFNET GUI
         qcrpNN.rpFFNET_gui(cf,ds,FFNET_info)
     else:
@@ -373,7 +373,7 @@ def ERUsingLloydTaylor(cf, ds, info):
                "er":info["er"]["rpLT"]}
     call_mode = qcutils.get_keyvaluefromcf(cf,["Options"],"call_mode",default="interactive")
     LT_info["call_mode"]= call_mode
-    if call_mode.lower()=="interactive": LT_info["show_plots"] = True
+    #if call_mode.lower()=="interactive": LT_info["show_plots"] = True
     # set the figure number
     if len(plt.get_fignums())==0:
         fig_num = 0
@@ -579,7 +579,7 @@ def ERUsingSOLO(cf, ds, info):
     # check to see if this is a batch or an interactive run
     call_mode = qcutils.get_keyvaluefromcf(cf,["Options"],"call_mode",default="interactive")
     solo_info["call_mode"]= call_mode
-    if call_mode.lower()=="interactive": solo_info["show_plots"] = True
+    #if call_mode.lower()=="interactive": solo_info["show_plots"] = True
     if call_mode.lower()=="interactive":
         # call the ERUsingSOLO GUI
         qcrpNN.rpSOLO_gui(cf,ds,solo_info)

--- a/scripts/qcrpLT.py
+++ b/scripts/qcrpLT.py
@@ -54,6 +54,9 @@ def get_configs_dict(cf,ds):
                                      "output_plots",default="False")
     configs_dict["output_plots"] = (opt=="True")
     opt = qcutils.get_keyvaluefromcf(cf,["ER","ER_LT","ERUsingLloydTaylor"],
+                                     "show_plots",default="False")
+    configs_dict["show_plots"] = (opt=="True")
+    opt = qcutils.get_keyvaluefromcf(cf,["ER","ER_LT","ERUsingLloydTaylor"],
                                      "target",default="ER")
     configs_dict["target"] = str(opt)
     opt = qcutils.get_keyvaluefromcf(cf,["ER","ER_LT","ERUsingLloydTaylor"],


### PR DESCRIPTION
… in order to process parts of the data set using differnt window length for gap-filling, start and endtime in GUI given and processing only runs from these start to end times (currently it always ran to the end of the dataset if "days" used.
- remove hard coded "showplots" = true if in interactive mode.