### PR TITLE
Fix wrong brackets in L6 template file.

### DIFF
--- a/controlfiles/templates/L5_and_L6/filter_at_L5/L6.txt
+++ b/controlfiles/templates/L5_and_L6/filter_at_L5/L6.txt
@@ -13,7 +13,7 @@ Fund."""
 [Options]
     MaxGapInterpolate   = 0
 
-[[ER]
+[ER]
    [[ER_SOLO]]
         [[[ERUsingSOLO]]]
             target ="ER"


### PR DESCRIPTION
Removed extra square bracket before ER on line 16 of filter_at_L5/L6.txt