### PR TITLE
Peter/fix do 7500check

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -2,10 +2,10 @@
 #import copy
 import datetime
 #import logging
-import matplotlib as mpl
-import matplotlib.style
-mpl.use('TkAgg')
-mpl.style.use('classic')
+import matplotlib
+#import matplotlib.style
+matplotlib.use('TkAgg')
+#matplotlib.style.use('classic')
 #matplotlib.use('Qt4Agg')
 #import numpy
 import ntpath

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,12 @@
 version_name = "PyFluxPro"
-version_number = "V0.1.5"
+version_number = "V0.1.6"
+# V0.1.6 - fixed bug in pfp_ck.do_li7500check()
+#          - bug caused by use of irga_dependents in final
+#            loop instead of irga_list
+#          - bug meant covariances (UzA, UzC etc) were not
+#            filtered based on dependencies on AGC_IRGA,
+#            Ah_IRGA_Sd and CO2_IRGA_Sd
+#          - bug was introduced on 15th July 2017 at V0.1.0
 # V0.1.5 - change source file names from qc*.py to pfp_*.py
 # V0.1.4 - implement MPT and MDS
 #          - implementation of u* threshold detection using the

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -675,7 +675,7 @@ def do_li7500check(cf, ds, code=4):
     percent = float(100)*numpy.size(idx)/numpy.size(flag)
     msg = msg + " (" + str(int(percent+0.5)) + "%)"
     logger.info(msg)
-    for label in irga_dependents:
+    for label in irga_list:
         ds.series[label]['Data'][idx] = numpy.float64(c.missing_value)
         ds.series[label]['Flag'][idx] = numpy.int32(code)
 


### PR DESCRIPTION
Another example of why I need to implement thorough testing of versions after modifications.
A bug in pfp_ck.do_li7500check(), introduced at V0.1.0 on 15/07/2017, meant that implicit dependencies (on AGC_IRGA, H2O_IRGA_Sd and CO2_IRGA_Sd) were not applied to covariances UzC, UzA etc.  This would result in noisier than usual fluxes Fe and Fc.
An email to all site PIs and data processors will be sent recommending all data processed after July 2017 be reprocessed using this version.