### PR TITLE
Fix bug in pfp_ts.MergeSeries()

### DIFF
--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -2539,10 +2539,11 @@ def MergeSeries(cf,ds,series,okflags=[0,10,20,30,40,50,60],convert_units=False,s
     Date: Back in the day
     History:
      16/7/2017 - made okflags optional, implemented save_originals
+     30/10/2018 - rewrote to use pfp_utils.GetVariable()
     """
     # check to see if the series is specified in the control file
     section = pfp_utils.get_cfsection(cf,series=series)
-    if len(section)==0: return
+    if len(section) == 0: return
     # check to see if the entry for series in the control file has the MergeSeries key
     if 'MergeSeries' not in cf[section][series].keys(): return
     # check to see if the series has already been merged
@@ -2553,64 +2554,83 @@ def MergeSeries(cf,ds,series,okflags=[0,10,20,30,40,50,60],convert_units=False,s
     if nSeries==0:
         logger.warning(' MergeSeries: no input series specified for '+str(series))
         return
-    if nSeries==1:
-        logger.info(' Merging '+str(srclist)+'==>'+series)
+    if nSeries == 1:
+        msg = ' Merging ' + str(srclist) + '==>' + series
+        logger.info(msg)
         primary_series = srclist[0]
         if primary_series not in ds.series.keys():
-            msg = "  MergeSeries: primary input series "+primary_series
-            msg = msg+" not found for "+str(series)
+            msg = "  MergeSeries: primary input series " + primary_series
+            msg = msg + " not found for " + str(series)
             logger.warning(msg)
             return
-        mdata,mflag,mattr = pfp_utils.GetSeriesasMA(ds,primary_series)
-        if (primary_series==series) and save_originals:
-            tmp_label = primary_series+"_b4merge"
-            pfp_utils.CreateSeries(ds,tmp_label,mdata,mflag,mattr)
+        #mdata,mflag,mattr = pfp_utils.GetSeriesasMA(ds,primary_series)
+        primary = pfp_utils.GetVariable(ds, primary_series)
+        if (primary_series == series) and save_originals:
+            tmp = pfp_utils.CopyVariable(primary)
+            tmp["Label"] = tmp["Label"] + "_b4merge"
+            pfp_utils.CreateVariable(ds, tmp)
         SeriesNameString = primary_series
     else:
-        logger.info(' Merging '+str(srclist)+'==>'+series)
+        msg = " Merging " + str(srclist) + "==>" + series
+        logger.info(msg)
         if srclist[0] not in ds.series.keys():
-            logger.warning('  MergeSeries: primary input series '+srclist[0]+' not found for '+str(series))
+            msg = "  MergeSeries: primary input series " + srclist[0] + " not found for " + str(series)
+            logger.warning(msg)
             return
         primary_series = srclist[0]
-        mdata,mflag,mattr = pfp_utils.GetSeriesasMA(ds,primary_series)
-        if (primary_series==series) and save_originals:
-            tmp_label = primary_series+"_b4merge"
-            pfp_utils.CreateSeries(ds,tmp_label,mdata,mflag,mattr)
+        #mdata,mflag,mattr = pfp_utils.GetSeriesasMA(ds,primary_series)
+        primary = pfp_utils.GetVariable(ds, primary_series)
+        p_recs = len(primary["Data"])
+        if (primary_series == series) and save_originals:
+            tmp = pfp_utils.CopyVariable(primary)
+            tmp["Label"] = tmp["Label"] + "_b4merge"
+            pfp_utils.CreateVariable(ds, tmp)
         SeriesNameString = primary_series
         srclist.remove(primary_series)
         for secondary_series in srclist:
             if secondary_series in ds.series.keys():
-                ndata,nflag,nattr = pfp_utils.GetSeriesasMA(ds,secondary_series)
-                if (secondary_series==series) and save_originals:
-                    tmp_label = secondary_series+"_b4merge"
-                    pfp_utils.CreateSeries(ds,tmp_label,ndata,nflag,nattr)
-                if nattr["units"]!=mattr["units"]:
-                    msg = " "+secondary_series+" units don't match "+primary_series+" units"
+                #ndata,nflag,nattr = pfp_utils.GetSeriesasMA(ds,secondary_series)
+                secondary = pfp_utils.GetVariable(ds, secondary_series)
+                s_recs = len(secondary["Data"])
+                if (secondary_series == series) and save_originals:
+                    tmp = pfp_utils.CopyVariable(secondary)
+                    tmp["Label"] = tmp["Label"] + "_b4merge"
+                    pfp_utils.CreateVariable(ds, tmp)
+                if secondary["Attr"]["units"] != primary["Attr"]["units"]:
+                    msg = " " + secondary_series + " units don't match " + primary_series + " units"
                     logger.warning(msg)
                     if convert_units:
-                        msg = " "+secondary_series+" units converted from "+nattr["units"]+" to "+mattr["units"]
+                        msg = " " + secondary_series + " units converted from "
+                        msg = msg + secondary["Attr"]["units"] + " to " + primary["Attr"]["units"]
                         logger.info(msg)
-                        ndata = pfp_utils.convert_units_func(ds,ndata,nattr["units"],mattr["units"])
+                        secondary = pfp_utils.convert_units_func(ds, secondary, primary["Attr"]["units"])
                     else:
-                        msg = " MergeSeries: "+secondary_series+" ignored"
+                        msg = " MergeSeries: " + secondary_series + " ignored"
                         logger.error(msg)
                         continue
-                SeriesNameString = SeriesNameString+', '+secondary_series
-                indx1 = numpy.zeros(numpy.size(mdata),dtype=numpy.int)
-                indx2 = numpy.zeros(numpy.size(ndata),dtype=numpy.int)
+                SeriesNameString = SeriesNameString + ", " + secondary_series
+                p_idx = numpy.zeros(p_recs, dtype=numpy.int)
+                s_idx = numpy.zeros(s_recs, dtype=numpy.int)
                 for okflag in okflags:
-                    index = numpy.where(mflag==okflag)[0]   # index of acceptable primary values
-                    indx1[index] = 1                        # set primary index to 1 when primary good
-                    index = numpy.where(nflag==okflag)[0]   # same process for secondary
-                    indx2[index] = 1
-                index = numpy.where((indx1!=1)&(indx2==1))[0]           # index where primary bad but secondary good
-                mdata[index] = ndata[index]       # replace bad primary with good secondary
-                mflag[index] = nflag[index]
+                    # index of acceptable primary values
+                    index = numpy.where(primary["Flag"] == okflag)[0]
+                    # set primary index to 1 when primary good
+                    p_idx[index] = 1
+                    # same process for secondary
+                    index = numpy.where(secondary["Flag"] == okflag)[0]
+                    s_idx[index] = 1
+                # index where primary bad but secondary good
+                index = numpy.where((p_idx != 1 ) & (s_idx == 1))[0]
+                # replace bad primary with good secondary
+                primary["Data"][index] = secondary["Data"][index]
+                primary["Flag"][index] = secondary["Flag"][index]
             else:
-                logger.warning("  MergeSeries: secondary input series "+secondary_series+" not found")
+                msg = "  MergeSeries: secondary input series " + secondary_series + " not found"
+                logger.warning(msg)
     ds.mergeserieslist.append(series)
-    mattr["long_name"] = mattr["long_name"]+", merged from " + SeriesNameString
-    pfp_utils.CreateSeries(ds,series,mdata,mflag,mattr)
+    primary["Label"] = series
+    primary["Attr"]["long_name"] += ", merged from " + SeriesNameString
+    pfp_utils.CreateVariable(ds, primary)
 
 def PT100(ds,T_out,R_in,m):
     logger.info(' Calculating temperature from PT100 resistance')

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -300,18 +300,19 @@ def convert_units_func(ds, variable, new_units, mode="quiet"):
      Generic routine for changing units.
      Nothing is done if the original units are the same as the requested units.
     Usage:
-     new_data = pfp_utils.convert_units_func(old_data,old_units,new_units)
-     where old_data is a 1D array of data in the original units
-           old_units are the units of the original data
-           new_units are the units of the new data
-           ts is the time step
+     new_variable = pfp_utils.convert_units_func(ds, old_variable, new_units)
+     where;
+      new_variable is a copy of old_variable converted to new_units
+      ds is a data structure
+      old_variable is a variable in the original units
+      new_units are the units of the new data
     Author: PRI
     Date: July 2015
     """
     old_units = variable["Attr"]["units"]
     if old_units == new_units:
         # old units same as new units, nothing to do ...
-        return
+        return variable
     # check the units are something we understand
     # add more lists here to cope with water etc
     co2_list = ["umol/m2/s","gC/m2","mg/m3","mgCO2/m3","umol/mol","mg/m2/s","mgCO2/m2/s"]
@@ -853,6 +854,24 @@ def CreateSeries(ds,Label,Data,Flag,Attr):
             ds.series['_tmp_']['Attr'][item] = Attr[item]
     ds.series[unicode(Label)] = ds.series['_tmp_']     # copy temporary series to new series
     del ds.series['_tmp_']                        # delete the temporary series
+
+def CopyVariable(variable):
+    """
+    Purpose:
+     Make a shallow-ish copy of a variable.
+    Usage:
+     variable_copy = pfp_utils.CopyVariable(variable)
+    Author: PRI
+    Date: October 2018
+    """
+    tmp = {"Data":Fsd["Data"], "Flag":Fsd["Flag"], "Attr":Fsd["Attr"]}
+    if "Label" in Fsd:
+        tmp["Label"] = Fsd["Label"]
+    if "DateTime" in Fsd:
+        tmp["DateTime"] = Fsd["DateTime"]
+    if "time_step" in Fsd:
+        tmp["time_step"] = Fsd["time_step"]
+    return tmp
 
 def CreateDatetimeRange(start,stop,step=datetime.timedelta(minutes=30)):
     '''


### PR DESCRIPTION
MergeSeries() was still using the old style call to convert_units_func().  convert_units_func() was updated some time ago to use pfp_utils.GetVariable() to get data out of the data structure.
Rewrote pfp_ts.MergeSeries() to use pfp_utils.GetVariable().
Tested on Calperum 2016 L3 data by comparing data from this version with data from previous version, all merged variables were identical.