### PR TITLE
Change entry in environment.yml from dateutil to python-dateutil.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
-name: pfp_env
+name: pfp_env2
 channels:
   - conda-forge
 dependencies:
   - python=2.7
   - configobj
-  - dateutil
+  - python-dateutil
   - matplotlib
   - netcdf4
   - numpy


### PR DESCRIPTION
The name of the dateutil package in conda-forge seems to have been changed to python-dateutil.  Problems creating environment reported by Nina and Richard, confirmed by PRI on Win10.  Fixed by changing the name in yml file and tested on Ubuntu 16.04, Win7 and OSX (High Sierra).