### PR TITLE
Handle change of default outut from cftime V1.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=2.7
+  - cftime
   - configobj
   - python-dateutil
   - matplotlib


### PR DESCRIPTION
In cftime V1.1.0 and above, num2date() returns a cftime object by default, not a Python datetime object as in previous versions.
Used a try ... except clause in pfp_utils.get_datetimefromnctime() to try cftime.num2pydate() (works if cftime version >+ V1.1.0) first and fall through to cftime.num2date() (works if cftime version < V1.1.0) if this fails with an AttributeError.