### PR TITLE
Remove references to Year, Month, Day, Hour or Minute in data structure

### DIFF
--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -450,20 +450,41 @@ def do_dependencycheck(cf, ds, section, series, code=23, mode="quiet"):
     # our work here is done
     return
 
-def do_diurnalcheck(cf,ds,section,series,code=5):
-    if 'DiurnalCheck' not in cf[section][series].keys(): return
-    if 'NumSd' not in cf[section][series]['DiurnalCheck'].keys(): return
-    dt = float(ds.globalattributes['time_step'])
-    n = int((60./dt) + 0.5)             #Number of timesteps per hour
-    nInts = int((1440.0/dt)+0.5)        #Number of timesteps per day
-    Av = numpy.array([c.missing_value]*nInts,dtype=numpy.float64)
-    Sd = numpy.array([c.missing_value]*nInts,dtype=numpy.float64)
+def do_diurnalcheck(cf, ds, section, series, code=5):
+    """
+    Purpose:
+     Do the diurnal QC check on the series for which it has been requested.
+     The diurnal QC check works as follows:
+      - get the diurnal statistics (average and standard deviation) for each month
+        - the diurnal statistics are calculated from the
+          data at each time step through out the day
+        - there are 48 (24) diurnal values each day for
+          a time step of 30 (60) minutes
+      - mask any points that lie outside the average +/- NumSd*standard deviation
+        where NumSd is specified by the user in the control file
+    Usage:
+    Side effects:
+    Author: PRI
+    Date: Back in the day, tidied up in April 2020 during the COVID-19 lockdown
+    """
+    if "DiurnalCheck" not in cf[section][series].keys():
+        return
+    if "NumSd" not in cf[section][series]["DiurnalCheck"].keys():
+        return
+    ts = float(ds.globalattributes['time_step'])
+    n = int((60./ts) + 0.5)             #Number of timesteps per hour
+    nInts = int((1440.0/ts)+0.5)        #Number of timesteps per day
+    Av = numpy.array([c.missing_value]*nInts, dtype=numpy.float64)
+    Sd = numpy.array([c.missing_value]*nInts, dtype=numpy.float64)
     NSd = numpy.array(parse_rangecheck_limit(cf[section][series]['DiurnalCheck']['NumSd']))
-    for m in range(1,13):
-        mindex = numpy.where(ds.series['Month']['Data']==m)[0]
-        if len(mindex)!=0:
-            lHdh = ds.series['Hdh']['Data'][mindex]
-            l2ds = ds.series[series]['Data'][mindex]
+    ldt = pfp_utils.GetVariable(ds, "DateTime")
+    month = numpy.array([d.month for d in ldt["Data"]])
+    Hdh = numpy.array([(d.hour + d.minute/float(60)) for d in ldt["Data"]])
+    for m in range(1, 13):
+        mindex = numpy.where(month == m)[0]
+        if len(mindex) != 0:
+            lHdh = Hdh[mindex]
+            l2ds = ds.series[series]["Data"][mindex]
             for i in range(nInts):
                 li = numpy.where((abs(lHdh-(float(i)/float(n)))<c.eps)&(l2ds!=float(c.missing_value)))
                 if numpy.size(li)!=0:
@@ -477,9 +498,10 @@ def do_diurnalcheck(cf,ds,section,series,code=5):
             hindex = numpy.array(n*lHdh,int)
             index = numpy.where(((l2ds!=float(c.missing_value))&(l2ds<Lwr[hindex]))|
                                 ((l2ds!=float(c.missing_value))&(l2ds>Upr[hindex])))[0] + mindex[0]
-            ds.series[series]['Data'][index] = numpy.float64(c.missing_value)
-            ds.series[series]['Flag'][index] = numpy.int32(code)
-            ds.series[series]['Attr']['diurnalcheck_numsd'] = cf[section][series]['DiurnalCheck']['NumSd']
+            ds.series[series]["Data"][index] = numpy.float64(c.missing_value)
+            ds.series[series]["Flag"][index] = numpy.int32(code)
+            ds.series[series]["Attr"]["diurnalcheck_numsd"] = cf[section][series]["DiurnalCheck"]["NumSd"]
+    return
 
 def do_EC155check(cf,ds):
     """
@@ -611,6 +633,8 @@ def do_excludehours(cf,ds,section,series,code=7):
     ldt = ds.series['DateTime']['Data']
     ExcludeList = cf[section][series]['ExcludeHours'].keys()
     NumExclude = len(ExcludeList)
+    Hour = numpy.array([d.hour for d in ldt])
+    Minute = numpy.array([d.minute for d in ldt])
     for i in range(NumExclude):
         exclude_hours_string = cf[section][series]['ExcludeHours'][str(i)]
         ExcludeHourList = exclude_hours_string.split(",")
@@ -627,10 +651,9 @@ def do_excludehours(cf,ds,section,series,code=7):
         for j in range(2,len(ExcludeHourList)):
             ExHr = datetime.datetime.strptime(ExcludeHourList[j],'%H:%M').hour
             ExMn = datetime.datetime.strptime(ExcludeHourList[j],'%H:%M').minute
-            index = numpy.where((ds.series['Hour']['Data'][si:ei]==ExHr)&
-                                (ds.series['Minute']['Data'][si:ei]==ExMn))[0] + si
-            ds.series[series]['Data'][index] = numpy.float64(c.missing_value)
-            ds.series[series]['Flag'][index] = numpy.int32(code)
+            idx = numpy.where((Hour[si:ei] == ExHr) & (Minute[si:ei] == ExMn))[0] + si
+            ds.series[series]['Data'][idx] = numpy.float64(c.missing_value)
+            ds.series[series]['Flag'][idx] = numpy.int32(code)
             ds.series[series]['Attr']['ExcludeHours_'+str(i)] = cf[section][series]['ExcludeHours'][str(i)]
 
 def do_IRGAcheck(cf,ds):
@@ -875,6 +898,9 @@ def do_rangecheck(cf, ds, section, series, code=2):
         msg = "RangeCheck: key not found in control file for "+series+", skipping ..."
         logger.warning(msg)
         return
+    # get the month from the datetime series
+    ldt = pfp_utils.GetVariable(ds, "DateTime")
+    month = numpy.array([d.month for d in ldt["Data"]])
     # get the upper and lower limits
     upper = cf[section][series]['RangeCheck']['Upper']
     upr = numpy.array(parse_rangecheck_limit(upper))
@@ -882,8 +908,8 @@ def do_rangecheck(cf, ds, section, series, code=2):
         msg = " Need 12 'Upper' values, got "+str(len(upr))+" for "+series
         logger.error(msg)
         return
-    valid_upper = numpy.min(upr)
-    upr = upr[ds.series['Month']['Data']-1]
+    valid_upper = numpy.max(upr)
+    upr = upr[month - 1]
     lower = cf[section][series]['RangeCheck']['Lower']
     lwr = numpy.array(parse_rangecheck_limit(lower))
     if len(lwr) != 12:
@@ -891,7 +917,7 @@ def do_rangecheck(cf, ds, section, series, code=2):
         logger.error(msg)
         return
     valid_lower = numpy.min(lwr)
-    lwr = lwr[ds.series['Month']['Data']-1]
+    lwr = lwr[month - 1]
     # get the data, flag and attributes
     data, flag, attr = pfp_utils.GetSeriesasMA(ds, series)
     # convert the data from a masked array to an ndarray so the range check works

--- a/scripts/pfp_clim.py
+++ b/scripts/pfp_clim.py
@@ -220,8 +220,8 @@ def climatology(cf):
     SiteName = ds.globalattributes['site_name']
     # get the datetime series
     dt = ds.series['DateTime']['Data']
-    Hdh = ds.series['Hdh']['Data']
-    Month = ds.series['Month']['Data']
+    Hdh = numpy.array([(d.hour + d.minute/float(60)) for d in dt])
+    Month = numpy.array([d.month for d in dt])
     # get the initial start and end dates
     StartDate = str(dt[0])
     EndDate = str(dt[-1])

--- a/scripts/pfp_func.py
+++ b/scripts/pfp_func.py
@@ -227,7 +227,7 @@ def DateTimeFromExcelDateAndTime(ds, dt_out, xlDate, xlTime):
     xldatetime["Attr"]["long_name"] = "Date/time in Excel format"
     xldatetime["Attr"]["units"] = "days since 1899-12-31 00:00:00"
     pfp_utils.CreateVariable(ds, xldatetime)
-    pfp_utils.get_datetimefromxldate(ds)
+    pfp_utils.get_datetime_from_xldate(ds)
     return 1
 
 def DateTimeFromDateAndTimeString(ds, dt_out, Date, Time):

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -1140,19 +1140,23 @@ def gfClimatology_interpolateddaily(ds, series, output, xlbook, flag_code):
     # put the gap filled data back into the data structure
     pfp_utils.CreateSeries(ds, output, data, flag, attr)
 
-def gfClimatology_monthly(ds,series,output,xlbook):
+def gfClimatology_monthly(ds, series, output, xlbook):
     """ Gap fill using monthly climatology."""
+    ldt = pfp_utils.GetVariable(ds, "DateTime")
+    Hdh = numpy.array([(d.hour + d.minute/float(60)) for d in ldt["Data"]])
+    Month = numpy.array([d.month for d in ldt["Data"]])
     thissheet = xlbook.sheet_by_name(series)
     val1d = numpy.zeros_like(ds.series[series]['Data'])
-    values = numpy.zeros([48,12])
-    for month in range(1,13):
-        xlCol = (month-1)*5 + 2
-        values[:,month-1] = thissheet.col_values(xlCol)[2:50]
+    values = numpy.zeros([48, 12])
+    for month in range(1, 13):
+        m = (month - 1)
+        xlCol = m*5 + 2
+        values[:, m] = thissheet.col_values(xlCol)[2:50]
     for i in range(len(ds.series[series]['Data'])):
-        h = numpy.int(2*ds.series['Hdh']['Data'][i])
-        m = numpy.int(ds.series['Month']['Data'][i])
-        val1d[i] = values[h,m-1]
-    index = numpy.where(abs(ds.series[output]['Data']-c.missing_value)<c.eps)[0]
+        h = numpy.int(2*Hdh[i])
+        m = numpy.int(Month[i])
+        val1d[i] = values[h, m-1]
+    index = numpy.where(abs(ds.series[output]['Data']-c.missing_value) < c.eps)[0]
     ds.series[output]['Data'][index] = val1d[index]
     ds.series[output]['Flag'][index] = numpy.int32(40)
 

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -36,7 +36,7 @@ def l1qc(cf):
         if ds1.returncodes["value"] != 0:
             return ds1
         # get a series of Python datetime objects from the Excel datetime
-        #pfp_utils.get_datetimefromxldate(ds1)
+        #pfp_utils.get_datetime_from_xldate(ds1)
     # get the netCDF attributes from the control file
     #pfp_ts.do_attributes(cf,ds1)
     pfp_utils.get_datetime(cf, ds1)
@@ -47,9 +47,9 @@ def l1qc(cf):
     if pfp_utils.CheckTimeStep(ds1):
         pfp_utils.FixTimeStep(ds1, fixtimestepmethod=fixtimestepmethod)
     # recalculate the Excel datetime
-    pfp_utils.get_xldatefromdatetime(ds1)
+    #pfp_utils.get_xldatefromdatetime(ds1)
     # get the Year, Month, Day etc from the Python datetime
-    pfp_utils.get_ymdhmsfromdatetime(ds1)
+    #pfp_utils.get_ymdhmsfromdatetime(ds1)
     # write the processing level to a global attribute
     ds1.globalattributes['nc_level'] = str("L1")
     # get the start and end date from the datetime series unless they were
@@ -63,7 +63,7 @@ def l1qc(cf):
     # create new variables using user defined functions
     pfp_ts.DoFunctions(cf,ds1)
     # create a series of synthetic downwelling shortwave radiation
-    pfp_ts.get_synthetic_fsd(ds1)
+    #pfp_ts.get_synthetic_fsd(ds1)
     # check missing data and QC flags are consistent
     pfp_utils.CheckQCFlags(ds1)
 

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -523,7 +523,7 @@ def plottimeseries(cf, nFig, dsa, dsb):
             plot_onetimeseries_right(fig,n,ThisOne,L2XArray,L2YArray,p)
 
             #Plot the diurnal averages.
-            Hr2,Av2,Sd2,Mx2,Mn2=get_diurnalstats(dsb.series['Hdh']['Data'], dsb.series[ThisOne]['Data'], ts)
+            Hr2, Av2, Sd2, Mx2, Mn2 = get_diurnalstats(Hdh, dsb.series[ThisOne]['Data'], ts)
             Av2 = numpy.ma.masked_where(Av2==c.missing_value,Av2)
             Sd2 = numpy.ma.masked_where(Sd2==c.missing_value,Sd2)
             Mx2 = numpy.ma.masked_where(Mx2==c.missing_value,Mx2)
@@ -807,12 +807,16 @@ def plot_quickcheck(cf):
     EndDate = str(DateTime[-1])
     # get the 30 minute data from the data structure
     logger.info(" Getting data from data structure")
-    data_list = ["Month", "Hour", "Minute",
-                 "Fsd", "Fsu", "Fld", "Flu", "Fn",
+    data = {"Month":{"Attr":{}}, "Hour":{"Attr":{}}, "Minute":{"Attr":{}}}
+    # do the month, hour and minute separately
+    data["Month"]["Data"] = numpy.array([d.month for d in DateTime])
+    data["Hour"]["Data"] = numpy.array([d.hour for d in DateTime])
+    data["Minute"]["Data"] = numpy.array([d.minute for d in DateTime])
+    # now do the data we want to plot
+    data_list = ["Fsd", "Fsu", "Fld", "Flu", "Fn",
                  "Fg", "Fa", "Fe", "Fh", "Fc", "ustar",
                  "Ta", "H2O", "CO2", "Precip", "Ws",
                  "Sws", "Ts"]
-    data = {}
     for label in data_list:
         if label in series_list:
             data[label] = pfp_utils.GetVariable(ds, label, start=si, end=ei)
@@ -1177,7 +1181,7 @@ def xyplot(x,y,sub=[1,1,1],regr=0,thru0=0,title=None,xlabel=None,ylabel=None,fna
             logger.info("xyplot: nothing to plot!")
     if thru0!=0:
         x = x[:,numpy.newaxis]
-        a, _, _, _ = numpy.linalg.lstsq(x, y)
+        a, _, _, _ = numpy.linalg.lstsq(x, y, rcond=-1)
         eqnstr = 'y = %.3fx'%(a)
         plt.text(0.5,0.875,eqnstr,fontsize=8,horizontalalignment='center',transform=ax.transAxes)
     return

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -439,6 +439,8 @@ def convert_units_co2(ds, variable, new_units):
         variable["Attr"]["units"] = new_units
     elif old_units in ["mg/m3", "mgCO2/m3"] and new_units=="umol/mol":
         # convert the data
+        ldt = GetVariable(ds, "DateTime")
+        Month = numpy.array([d.month for d in ldt["Data"]])
         Ta = GetVariable(ds, "Ta")
         ps = GetVariable(ds, "ps")
         Ta_def = numpy.full(12, numpy.ma.mean(Ta["Data"]))
@@ -457,7 +459,7 @@ def convert_units_co2(ds, variable, new_units):
                 for m, item in enumerate(limit_list):
                     month = m + 1
                     # get an index of the months
-                    idx = numpy.where(ds.series["Month"]==month)[0]
+                    idx = numpy.where(Month == month)[0]
                     # move on to next month if this one not in data
                     if len(idx) == 0:
                         continue
@@ -494,6 +496,8 @@ def convert_units_co2(ds, variable, new_units):
         # update the variable attributes to the new units
         variable["Attr"]["units"] = new_units
     elif old_units=="umol/mol" and new_units in ["mg/m3","mgCO2/m3"]:
+        ldt = GetVariable(ds, "DateTime")
+        Month = numpy.array([d.month for d in ldt["Data"]])
         Ta = GetVariable(ds, "Ta")
         ps = GetVariable(ds, "ps")
         Ta_def = numpy.full(12, numpy.ma.mean(Ta["Data"]))
@@ -512,7 +516,7 @@ def convert_units_co2(ds, variable, new_units):
                 for m, item in enumerate(limit_list):
                     month = m + 1
                     # get an index of the months
-                    idx = numpy.where(ds.series["Month"]==month)[0]
+                    idx = numpy.where(Month == month)[0]
                     # move on to next month if this one not in data
                     if len(idx) == 0:
                         continue
@@ -1891,7 +1895,7 @@ def get_datetime(cf, ds):
     Date: August 2018
     """
     if "xlDateTime" in ds.series.keys():
-        get_datetimefromxldate(ds)
+        get_datetime_from_xldate(ds)
     elif "DateTime" in cf["Variables"].keys():
         if "Function" in cf["Variables"]["DateTime"]:
             # call the function given in the control file to convert the date/time string to a datetime object
@@ -1903,7 +1907,7 @@ def get_datetime(cf, ds):
             result = getattr(pfp_func,function_name)(ds, "DateTime", *function_args)
     return
 
-def get_datetimefromnctime(ds,time,time_units):
+def get_datetime_from_nctime(ds):
     """
     Purpose:
      Create a series of datetime objects from the time read from a netCDF file.
@@ -1914,26 +1918,24 @@ def get_datetimefromnctime(ds,time,time_units):
     Author: PRI
     Date: September 2014
     """
-    ts = int(ds.globalattributes["time_step"])
     nRecs = int(ds.globalattributes["nc_nrecs"])
+    nc_time_data = ds.series["time"]["Data"]
+    nc_time_units = ds.series["time"]["Attr"]["units"]
     # handle the change of default return object introduced at cftime V1.1.0
     try:
         # try cftime.num2pydate() first
         # should work for cftime V1.1.0 and above
-        dt = cftime.num2pydate(time, time_units)
+        dt = cftime.num2pydate(nc_time_data, nc_time_units)
     except AttributeError:
         # use cftime.num2date() if cftime.num2pydate() doesn't exist
         # should work for cftime less than V1.1.0
-        dt = cftime.num2date(time, time_units)
-    ds.series[unicode("DateTime")] = {}
-    ds.series["DateTime"]["Data"] = dt
-    ds.series["DateTime"]["Flag"] = numpy.zeros(nRecs)
-    ds.series["DateTime"]["Attr"] = {}
-    ds.series["DateTime"]["Attr"]["long_name"] = "Datetime in local timezone"
-    ds.series["DateTime"]["Attr"]["units"] = "None"
+        dt = cftime.num2date(nc_time_data, nc_time_units)
+    pydt = {"Label": "DateTime", "Data": dt, "Flag": numpy.zeros(nRecs),
+            "Attr": {"long_name": "Datetime in local timezone", "units": "None"}}
+    CreateVariable(ds, pydt)
     return
 
-def get_datetimefromxldate(ds):
+def get_datetime_from_xldate(ds):
     ''' Creates a series of Python datetime objects from the Excel date read from the Excel file.
         Thanks to John Machin for the quick and dirty code
          see http://stackoverflow.com/questions/1108428/how-do-i-read-a-date-in-excel-format-in-python'''
@@ -1952,30 +1954,6 @@ def get_datetimefromxldate(ds):
     ds.series['DateTime']['Attr'] = {}
     ds.series['DateTime']['Attr']['long_name'] = 'Datetime in local timezone'
     ds.series['DateTime']['Attr']['units'] = 'None'
-
-def get_datetimefromymdhms(ds):
-    ''' Creates a series of Python datetime objects from the year, month,
-    day, hour, minute and second series stored in the netCDF file.'''
-    SeriesList = ds.series.keys()
-    if ('Year' not in SeriesList or 'Month' not in SeriesList or 'Day' not in SeriesList or
-        'Hour' not in SeriesList or 'Minute' not in SeriesList or 'Second' not in SeriesList):
-        logger.info(' get_datetimefromymdhms: unable to find all datetime fields required')
-        return
-    logger.info(' Getting the date and time series')
-    year = ds.series["Year"]["Data"]
-    month = ds.series["Month"]["Data"]
-    day = ds.series["Day"]["Data"]
-    hour = ds.series["Hour"]["Data"]
-    minute = ds.series["Minute"]["Data"]
-    second = ds.series["Second"]["Data"]
-    dt = [datetime.datetime(yr,mn,dy,hr,mi,se) for yr,mn,dy,hr,mi,se in zip(year,month,day,hour,minute,second)]
-    ds.series["DateTime"] = {}
-    ds.series["DateTime"]["Data"] = numpy.array(dt)
-    ds.series["DateTime"]["Flag"] = numpy.zeros(len(dt))
-    ds.series["DateTime"]["Attr"] = {}
-    ds.series["DateTime"]["Attr"]["long_name"] = "Datetime in local timezone"
-    ds.series["DateTime"]["Attr"]["units"] = "None"
-    return
 
 def get_ddoy_from_datetime(dt):
     """ Return the decimal day of the year from a datetime."""


### PR DESCRIPTION
Early versions of PFP stored series for the year, month, day, hour, minute, decimal hour (Hdh) and decimal day (Ddd) in the data structure.  This is now deprecated.  Only the Python datetime, calculated from the netCDF "time" variable, is stored in the data structure and any required dates or times are calculated from the Python datetime when required.