### PR TITLE
Peter/disable explicit background

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -13,9 +13,12 @@ import matplotlib
 if platform.system() == "Darwin":
     # set backend to "macosx" on Macs
     matplotlib.use("macosx")
-#else:
-    ## set backend to "QT5Agg" for Windows and Linux
-    #matplotlib.use("QT5Agg")
+elif platform.system() == "Windows":
+    # set backend to "QT5Agg" for Windows
+    matplotlib.use("QT5Agg")
+else:
+    # use whatever on Linux ...
+    pass
 from PyQt5 import QtWidgets
 # PFP modules
 sys.path.append('scripts')

--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -13,9 +13,9 @@ import matplotlib
 if platform.system() == "Darwin":
     # set backend to "macosx" on Macs
     matplotlib.use("macosx")
-else:
-    # set backend to "QT5Agg" for Windows and Linux
-    matplotlib.use("QT5Agg")
+#else:
+    ## set backend to "QT5Agg" for Windows and Linux
+    #matplotlib.use("QT5Agg")
 from PyQt5 import QtWidgets
 # PFP modules
 sys.path.append('scripts')


### PR DESCRIPTION
Explicitly setting the matplotlib backend to QTAgg in Linux cause QtAttribute error.  Make backend explicit for Windows and Mac OSX, leave Linux as default specified in matplotlibrc file.