### PR TITLE
Handle white space in Plots/variables at L2 and L3.

### DIFF
--- a/scripts/pfp_cfg.py
+++ b/scripts/pfp_cfg.py
@@ -2,7 +2,7 @@
 
 def cfg_string_to_list(input_string):
     """ Convert a string containing items separated by commas into a list."""
-    input_string = input_string.replace(" ", "")
+    input_string = "".join(input_string.split())
     if "," in input_string:
         output_list = input_string.split(",")
     else:

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -1036,10 +1036,7 @@ def plot_setup(cf, title):
         p["plot_path"] = os.path.join("plots", cf["level"])
     p['PlotDescription'] = str(title)
     var_string = cf['Plots'][str(title)]['variables']
-    if "," in var_string:
-        p['SeriesList'] = var_string.split(",")
-    else:
-        p['SeriesList'] = [var_string]
+    p['SeriesList'] = pfp_cfg.cfg_string_to_list(var_string)
     p['nGraphs'] = len(p['SeriesList'])
     p['PlotWidth'] = 13
     p['PlotHeight'] = 8


### PR DESCRIPTION
Any white space in the comma separated string of variables in Plots/variables causes that variable to be skipped.  White space now stripped from variables string.