### PR TITLE
Fix bug in MDS

### DIFF
--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -322,7 +322,7 @@ def do_SONICcheck(cf, ds, code=3):
     if "Diag_SONIC" in series_list:
         pass
     elif "Diag_CSAT" in series_list:
-        ds.series[unicode("Diag_SONIC")] = copy.deepcopy(ds.series["Diag_CSAT"])
+        ds.series["Diag_SONIC"] = copy.deepcopy(ds.series["Diag_CSAT"])
     else:
         msg = " Sonic diagnostics not found in data, skipping sonic checks ..."
         logger.warning(msg)

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -707,6 +707,11 @@ def gfMDS_createdict(cf, ds, l5_info, label, called_by, flag_code):
     Author: PRI
     Date: May 2018
     """
+    nrecs = int(ds.globalattributes["nc_nrecs"])
+    # make the L5 "description" attrubute for the target variable
+    descr_level = "description_" + ds.globalattributes["nc_level"]
+    ds.series[label]["Attr"][descr_level] = ""
+    # create the solo settings directory
     if called_by not in l5_info:
         l5_info[called_by] = {"outputs": {}, "info": {}}
     # file path and input file name

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -33,7 +33,7 @@ def GapFillUsingMDS(ds, l5_info, called_by):
     nc_full_path = os.path.join(file_path, file_name)
     nc_name = os.path.split(nc_full_path)[1]
     # get some useful metadata
-    ts = int(ds.globalattributes["nc_nrecs"])
+    ts = int(ds.globalattributes["time_step"])
     site_name = ds.globalattributes["site_name"]
     level = ds.globalattributes["nc_level"]
     # define the MDS input file location
@@ -221,7 +221,7 @@ def gfMDS_make_data_array(ds, current_year, info):
     Date: May 2018
     """
     ldt = pfp_utils.GetVariable(ds, "DateTime")
-    nrecs = ds.globalattributes["nc_nrecs"]
+    nrecs = int(ds.globalattributes["nc_nrecs"])
     ts = int(ds.globalattributes["time_step"])
     start = datetime.datetime(current_year,1,1,0,30,0)
     end = datetime.datetime(current_year+1,1,1,0,0,0)


### PR DESCRIPTION
MDS gap filling was issuing a warning from pfp_utils.GetDateIndex() because the default number of records was being passed as a string not an integer.