### PR TITLE
Coverage plot not displayed at L4, fixed.

### DIFF
--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -471,9 +471,12 @@ def gfalternate_createdict_gui(cf, ds, l4_info, called_by):
     opt = pfp_utils.get_keyvaluefromcf(cf, sl, "overwrite", default="no")
     if opt.lower() == "yes": l4a["gui"]["overwrite"] = True
     # show plots option
-    l4a["gui"]["show_plots"] = True
-    opt = pfp_utils.get_keyvaluefromcf(cf, sl, "show_plots", default="yes")
-    if opt.lower() == "no": l4a["gui"]["show_plots"] = False
+    if cf["Options"]["call_mode"].lower() == "interactive":
+        l4a["gui"]["show_plots"] = True
+    else:
+        opt = pfp_utils.get_keyvaluefromcf(cf, sl, "show_plots", default="yes")
+        if opt.lower() == "no":
+            l4a["gui"]["show_plots"] = False
     # show all plots option
     l4a["gui"]["show_all"] = False
     opt = pfp_utils.get_keyvaluefromcf(cf, sl, "show_all", default="no")


### PR DESCRIPTION
In interactive mode, L4 coverage plots not displayed if GUI section with sjow_plots = no in L4 control file.
Fixed by setting sjow_plots = True if mode = interactive.