### PR TITLE
Show plots batch

### DIFF
--- a/scripts/pfp_gfALT.py
+++ b/scripts/pfp_gfALT.py
@@ -122,12 +122,12 @@ def gfalternate_autocomplete(ds_tower, ds_alt, l4_info, called_by, mode="verbose
                     min_points = max([int(((gap[1]-gap[0])+1)*l4a["gui"]["min_percent"]/100),3*l4a["gui"]["nperhr"]])
                     if numpy.ma.count(data_alt[gap[0]: gap[1]]) >= min_points:
                         if mode.lower() != "quiet":
-                            msg = " autocomplete: " + label_tower + ldt_tower[gap[0]] + ldt_tower[gap[1]] + " got data to fill gap"
+                            msg = " autocomplete: " + label_tower + str(ldt_tower[gap[0]]) + str(ldt_tower[gap[1]]) + " got data to fill gap"
                             logger.info(msg)
                         gotdataforgap[n] = True
                     if numpy.ma.count_masked(data_tower[gap[0]: gap[1]]) == 0:
                         if mode.lower() != "quiet":
-                            msg = " autocomplete: "+label_tower + ldt_tower[gap[0]] + ldt_tower[gap[1]] + " no gap to fill"
+                            msg = " autocomplete: "+label_tower + str(ldt_tower[gap[0]]) + str(ldt_tower[gap[1]]) + " no gap to fill"
                             logger.info(msg)
                         gotdataforgap[n] = False
         # finished checking all alternate data sources for data to fill remaining gaps


### PR DESCRIPTION
L4 and L5 batch processing crashed due to ["show_plots"] not set. Changed default value from "yes" to "no" in pfp_utils.get_keyvaluefromcf(cf, sl, "show_plots", default="no") and now value is set for L4 and L5 batch processing too.