### PR TITLE
Fix use of plot_path to prevent it being written to control files.

### DIFF
--- a/scripts/pfp_batch.py
+++ b/scripts/pfp_batch.py
@@ -40,8 +40,9 @@ def do_batch_fingerprints(cfg):
     cfg_fp = pfp_io.get_controlfilecontents(cfg_fp_uri)
     file_name = pfp_io.get_outfilenamefromcf(cfg)
     file_path = os.path.join(os.path.split(file_name)[0], "")
+    plot_path = pfp_utils.get_keyvaluefromcf(cfg, ["Files"], "plot_path", default="plots/")
     cfg_fp["Files"] = {"file_path": file_path, "in_filename": os.path.split(file_name)[1],
-                       "plot_path": cfg["Files"]["plot_path"]}
+                       "plot_path": plot_path}
     cfg_fp["Options"] = {"call_mode": "batch", "show_plots": "No"}
     msg = "Doing fingerprint plots using " + cfg_fp["Files"]["in_filename"]
     logger.info(msg)

--- a/scripts/pfp_cpd_barr.py
+++ b/scripts/pfp_cpd_barr.py
@@ -42,9 +42,8 @@ def cpd_barr_main(cf):
     else:
         file_name = cf["Files"]["in_filename"].replace(".nc", "_CPD_Barr.xlsx")
         file_out = os.path.join(cf["Files"]["file_path"], file_name)
-    plot_path = "plots/"
-    if "plot_path" in cf["Files"]:
-        plot_path = os.path.join(cf["Files"]["plot_path"], "CPD/")
+    plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
+    plot_path = os.path.join(plot_path, "CPD", "")
     if not os.path.isdir(plot_path):
         os.makedirs(plot_path)
     results_path = path_out

--- a/scripts/pfp_cpd_mchugh.py
+++ b/scripts/pfp_cpd_mchugh.py
@@ -301,9 +301,10 @@ def CPD_run(cf):
     else:
         file_name = cf['Files']['in_filename'].replace(".nc","_CPD_McHugh.xlsx")
         file_out = os.path.join(cf['Files']['file_path'], file_name)
-    plot_path = "plots/"
-    if "plot_path" in cf["Files"]: plot_path = os.path.join(cf["Files"]["plot_path"],"CPD/")
-    if not os.path.isdir(plot_path): os.makedirs(plot_path)
+    plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
+    plot_path = os.path.join(plot_path, "CPD", "")
+    if not os.path.isdir(plot_path):
+        os.makedirs(plot_path)
     results_path = path_out
     if not os.path.isdir(results_path): os.makedirs(results_path)
     # get a dictionary of the variable names

--- a/scripts/pfp_cpd_mcnew.py
+++ b/scripts/pfp_cpd_mcnew.py
@@ -290,9 +290,8 @@ def cpd_mcnew_main(cfg):
     else:
         file_name = cfg['Files']['in_filename'].replace(".nc","_CPD_McNew.xlsx")
         results_path = os.path.join(cfg['Files']['file_path'], file_name)
-    plot_path = "plots/"
-    if "plot_path" in cfg["Files"]:
-        plot_path = os.path.join(cfg["Files"]["plot_path"], "CPD", "")
+    plot_path = pfp_utils.get_keyvaluefromcf(cfg, ["Files"], "plot_path", default="plots/")
+    plot_path = os.path.join(plot_path, "CPD", "")
     if not os.path.isdir(plot_path):
         os.makedirs(plot_path)
     # read the input file

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -1325,18 +1325,20 @@ def write_csv_fluxnet(cf):
     csvfile.close()
     return 1
 
-def get_controlfilecontents(ControlFileName, mode="verbose"):
+def get_controlfilecontents(cfg_file_uri, mode="verbose"):
+    """
+    Purpose:
+     Open a control fie and return its contents.
+    Author: PRI
+    Date: Back in the day
+    """
     if mode != "quiet":
         logger.info(" Processing the control file")
-    if len(ControlFileName) != 0:
-        cf = ConfigObj(ControlFileName, indent_type="    ", list_values=False)
-        cf["controlfile_name"] = ControlFileName
-    else:
-        cf = ConfigObj()
-    if "Files" in cf:
-        if "plot_path" not in list(cf["Files"].keys()):
-            cf["Files"]["plot_path"] = "plots/"
-    return cf
+    try:
+        cfg = ConfigObj(cfg_file_uri, indent_type="    ", list_values=False)
+    except Exception:
+        raise RuntimeError("Unable to open control file")
+    return cfg
 
 def get_ncdtype(Series):
     sd = Series.dtype.name

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -408,13 +408,7 @@ def plot_fingerprint(cf):
             plt.xlabel(label)
             if n!= 0:
                 plt.setp(ax.get_yticklabels(), visible=False)
-        if "Files" in cf:
-            if "plot_path" in cf["Files"]:
-                plot_path = cf["Files"]["plot_path"]+"fingerprints/"
-            else:
-                plot_path = "plots/"
-        else:
-            plot_path = "plots/"
+        plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="./plots/")
         if not os.path.exists(plot_path):
             os.makedirs(plot_path)
         pngname = plot_path + site_name.replace(" ","") + "_" + level + "_"
@@ -796,10 +790,7 @@ def plottimeseries(cf, nFig, dsa, dsb):
         else:
             logger.error('  plttimeseries: series '+ThisOne+' not in data structure')
         # get the plot path and save a hard copy of the plot
-        if "plot_path" in cf["Files"]:
-            plot_path = os.path.join(cf["Files"]["plot_path"],Level)
-        else:
-            plot_path = "plots/"
+        plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
         if not os.path.exists(plot_path):
             os.makedirs(plot_path)
         fname = os.path.join(plot_path, SiteName.replace(' ','')+'_'+Level+'_'+p['PlotDescription'].replace(' ','')+'.png')
@@ -1261,10 +1252,8 @@ def plot_quickcheck(cf):
 
 def plot_setup(cf, title):
     p = {}
-    if "plot_path" in cf["Files"]:
-        p["plot_path"] = os.path.join(cf["Files"]["plot_path"], cf["level"])
-    else:
-        p["plot_path"] = os.path.join("plots", cf["level"])
+    plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots")
+    p["plot_path"] = os.path.join(plot_path, cf["level"], "")
     p['PlotDescription'] = str(title)
     var_string = cf['Plots'][str(title)]['variables']
     p['SeriesList'] = pfp_utils.string_to_list(var_string)
@@ -1412,10 +1401,7 @@ def plotxy(cf, title, plt_cf, dsa, dsb):
             xyplot(xb,yb,sub=[1,2,2],regr=1,xlabel=xname,ylabel=yname)
     plt.draw()
     pfp_utils.mypause(0.5)
-    if "plot_path" in cf["Files"]:
-        plot_path = os.path.join(cf["Files"]["plot_path"],Level)
-    else:
-        plot_path = "plots/"
+    plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
     if not os.path.exists(plot_path):
         os.makedirs(plot_path)
     fname = os.path.join(plot_path, SiteName.replace(' ','')+'_'+Level+'_'+PlotDescription.replace(' ','')+'.png')

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -1273,7 +1273,8 @@ def L6_summary_plotdaily(cf, ds, daily_dict):
         plt.tight_layout()
         sdt = ddv["DateTime"]["data"][0].strftime("%Y%m%d")
         edt = ddv["DateTime"]["data"][-1].strftime("%Y%m%d")
-        plot_path = os.path.join(cf["Files"]["plot_path"], "L6", "")
+        plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
+        plot_path = os.path.join(plot_path, "L6", "")
         if not os.path.exists(plot_path): os.makedirs(plot_path)
         figure_name = site_name.replace(" ","")+"_CarbonBudget"+item+"_"+sdt+"_"+edt+'.png'
         figure_path = os.path.join(plot_path, figure_name)
@@ -1304,7 +1305,8 @@ def L6_summary_plotdaily(cf, ds, daily_dict):
     plt.tight_layout()
     sdt = ddv["DateTime"]["data"][0].strftime("%Y%m%d")
     edt = ddv["DateTime"]["data"][-1].strftime("%Y%m%d")
-    plot_path = cf["Files"]["plot_path"]+"L6/"
+    plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
+    plot_path = os.path.join(plot_path, "L6", "")
     if not os.path.exists(plot_path): os.makedirs(plot_path)
     figname = plot_path+site_name.replace(" ","")+"_SEB"
     figname = figname+"_"+sdt+"_"+edt+'.png'
@@ -1404,8 +1406,10 @@ def L6_summary_plotcumulative(cf, ds, cumulative_dict):
         # save a hard copy of the plot
         sdt = year_list[0]
         edt = year_list[-1]
-        plot_path = os.path.join(cf["Files"]["plot_path"], "L6", "")
-        if not os.path.exists(plot_path): os.makedirs(plot_path)
+        plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
+        plot_path = os.path.join(plot_path, "L6", "")
+        if not os.path.exists(plot_path):
+            os.makedirs(plot_path)
         figure_name = site_name.replace(" ", "")+"_Cumulative"+item+"_"+sdt+"_"+edt+'.png'
         figure_path = os.path.join(plot_path, figure_name)
         fig.savefig(figure_path, format='png')


### PR DESCRIPTION
plot_path was being written to the control file in pfp_io.get_controlfilecontents() as "plots/".  For some reason, this recently started adding plot_path to L1, concatenation, climatology etc whe these control files were opened, I think, in batch mode.
Fix was to remove the setting of plot_path in pfp_io.get_controlfilecontents() and tidy up the use of plot_path in the rest of the code.