### PR TITLE
Disable threading for batch runs :=(

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -736,9 +736,11 @@ class pfp_main_ui(QWidget):
             self.menuRun.addAction(self.actionStopCurrent)
             self.actionStopCurrent.triggered.connect(self.stop_current)
             # get a worker thread
-            worker = pfp_threading.Worker(pfp_top_level.do_run_batch, self)
+            #worker = pfp_threading.Worker(pfp_top_level.do_run_batch, self)
             # start the worker
-            self.threadpool.start(worker)
+            #self.threadpool.start(worker)
+            # no threading
+            pfp_top_level.do_run_batch(self)
         elif cfg["level"] == "L1":
             # check the L1 control file to see if it is OK to run
             if pfp_compliance.check_l1_controlfile(cfg):


### PR DESCRIPTION
It seems that using threading to run batch mode from the GUI works most of the time on Linux and Windows but not at all on MacOS.  The most likely culprit is matplotlib, which is known to be not thread-safe.  For now, I will disable threading when batch mode is run from the GUI and we will have to put up with the frozen GUI.