### PR TITLE
Fix sws rename l5

### DIFF
--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1598,6 +1598,7 @@ def update_cfg_variable_attributes(cfg, std):
                         if re in drivers:
                             idx = drivers.index(re)
                             drivers[idx] = std["Variables"]["rename_exact"][re]
+                    drivers = pfp_utils.list_to_string(drivers)
                     cfg[section_name][label_cfg][gfm][gfv]["drivers"] = drivers
 
                 # rename if first characters of variable name match pattern
@@ -1615,13 +1616,16 @@ def update_cfg_variable_attributes(cfg, std):
                     drivers = cfg[section_name][label_cfg][gfm][gfv]["drivers"]
                     drivers = pfp_utils.string_to_list(drivers)
                     for rp in renames_pattern:
-
-                        if rp in drivers:
-                            idx = drivers.index(re)
-                            drivers[idx] = std["Variables"]["rename_exact"][re]
+                        srp = std["Variables"]["rename_pattern"][rp]
+                        for driver in list(drivers):
+                            if (driver.split("_")[0] == rp):
+                                new_name = driver.replace(driver.split("_")[0], srp)
+                                idx = drivers.index(driver)
+                                drivers[idx] = new_name
+                    drivers = pfp_utils.list_to_string(drivers)
+                    cfg[section_name][label_cfg][gfm][gfv]["drivers"] = drivers
             else:
                 continue
-
     return cfg
 
 def update_cfg_variables_rename(cfg, std):

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1593,9 +1593,11 @@ def update_cfg_variable_attributes(cfg, std):
                 gfvs = list(cfg[section_name][label_cfg][gfm].keys())
                 for gfv in gfvs:
                     drivers = cfg[section_name][label_cfg][gfm][gfv]["drivers"]
+                    drivers = pfp_utils.string_to_list(drivers)
                     for re in renames_exact:
                         if re in drivers:
-                            drivers = drivers.replace(re, std["Variables"]["rename_exact"][re])
+                            idx = drivers.index(re)
+                            drivers[idx] = std["Variables"]["rename_exact"][re]
                     cfg[section_name][label_cfg][gfm][gfv]["drivers"] = drivers
 
                 # rename if first characters of variable name match pattern
@@ -1611,9 +1613,12 @@ def update_cfg_variable_attributes(cfg, std):
                 gfvs = list(cfg[section_name][label_cfg][gfm].keys())
                 for gfv in gfvs:
                     drivers = cfg[section_name][label_cfg][gfm][gfv]["drivers"]
+                    drivers = pfp_utils.string_to_list(drivers)
                     for rp in renames_pattern:
+
                         if rp in drivers:
-                            drivers = drivers.replace(rp, std["Variables"]["rename_pattern"][rp])
+                            idx = drivers.index(re)
+                            drivers[idx] = std["Variables"]["rename_exact"][re]
             else:
                 continue
 

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -2830,6 +2830,14 @@ def linear_function(B,x):
     """
     return B[0]*x + B[1]
 
+def list_to_string(l):
+    """ Convert list to comma separated string."""
+    if isinstance(l, list):
+        s = ",".join(l)
+    else:
+        s = ""
+    return s
+
 def make_attribute_dictionary(attr=None):
     """
     Purpose:


### PR DESCRIPTION
Sws was being renamed to SW_SONIC_Avs in the drivgers sub-section at L5.